### PR TITLE
Allow passing an option to encode all uri components or not

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,16 +2,17 @@ var querystring = require('querystring')
   , extend = require('extend')
   , url = require('url')
 
-module.exports = function appendQuery(uri, q) {
+module.exports = function appendQuery(uri, q, opts) {
   var parts = url.parse(uri, true)
     , parsedQuery = extend(true, {}, parts.query, typeof q === 'string' ? querystring.parse(q) : q)
+    , opts = opts ? opts : { encodeComponents: true };
 
-  parts.search = '?' + serialize(parsedQuery)
+  parts.search = '?' + serialize(parsedQuery, opts)
   return url.format(parts)
 }
 
 // serialize an object recursively
-function serialize(obj, prefix) {
+function serialize(obj, opts, prefix) {
   var str = []
     , useArraySyntax = false
 
@@ -29,8 +30,10 @@ function serialize(obj, prefix) {
       prop
 
     query = typeof val === 'object' ?
-      serialize(val, key) :
-      encodeURIComponent(key) + '=' + encodeURIComponent(val)
+      serialize(val, opts, key) :
+      opts.encodeComponents ?
+        encodeURIComponent(key) + '=' + encodeURIComponent(val) :
+        key + '=' + val;
 
     str.push(query)
   })

--- a/test/test.js
+++ b/test/test.js
@@ -35,3 +35,19 @@ test('should append query object with an array to url', function (t) {
     , expected = 'http://example.com/?beep%5B%5D=boop&beep%5B%5D=bop'
   t.equal(result, expected, 'should be equal')
 })
+
+// Options
+
+test('should encode a url if encodeComponents is truthy when passed as an option', function (t) {
+  t.plan(1)
+  var result = appendQuery('http://example.com/?foo="bar"', 'hello="world"', { encodeComponents: true })
+    , expected = 'http://example.com/?foo=%22bar%22&hello=%22world%22'
+  t.equal(result, expected, 'should be equal')
+})
+
+test('should not encode a url if encodeComponents is falsy when passed as an option', function (t) {
+  t.plan(1)
+  var result = appendQuery('http://example.com/?foo="bar"', 'hello="world"', { encodeComponents: false })
+    , expected = 'http://example.com/?foo="bar"&hello="world"'
+  t.equal(result, expected, 'should be equal')
+})


### PR DESCRIPTION
- Defaults to true so there is no effect on current users
- Added tests

The reason behind this change is to have a way to tell the library to not change the query string params it already received in the uri.
