### PR TITLE
queryString should be of local scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function appendQuery(uri, q, opts) {
     , opts = extend({}, module.defaults, opts || {});
 
   parts.query = null
-  queryString = serialize(parsedQuery, opts)
+  var queryString = serialize(parsedQuery, opts)
   parts.search = queryString ? '?' + queryString : null
   return url.format(parts)
 }


### PR DESCRIPTION
No explanation needed.
