### PR TITLE
Move extend upto ^2 to address vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "append-query",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Append querystring params to a URL.",
   "main": "index.js",
   "scripts": {
@@ -28,7 +28,7 @@
     "append"
   ],
   "dependencies": {
-    "extend": "^1.3.0"
+    "extend": "^2.0.0"
   },
   "devDependencies": {
     "tape": "^2.13.4"


### PR DESCRIPTION
snyk test append-query@2.0.1

Testing append-query@2.0.1...
✗ Low severity vulnerability found on extend@1.3.0
- desc: Prototype Pollution
- info: https://snyk.io/vuln/npm:extend:20180424
- from: append-query@2.0.1 > extend@1.3.0
Upgrade direct dependency extend@1.3.0 to extend@2.0.2