### PR TITLE
Updating dependencies to fix vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "append"
   ],
   "dependencies": {
-    "extend": "^2.0.0"
+    "extend": "^3.0.2"
   },
   "devDependencies": {
-    "tape": "^2.13.4"
+    "tape": "^5.2.2"
   }
 }


### PR DESCRIPTION
Retire (https://www.npmjs.com/package/retire) reported that a dependency containing a vulnerability was being pulled in via an old version of extend.

When I did 'npm install' npm reported a vulnerability in the version of tape being used. That is only a dev dependency but while I'm here I figured I may as well tidy it up.

Tests pass both before and after this change.